### PR TITLE
Fix: 게시글 미리보기 하단 디자인 수정

### DIFF
--- a/src/Components/PreviewArticle.styled.js
+++ b/src/Components/PreviewArticle.styled.js
@@ -51,6 +51,7 @@ const PreviewArticleDiv = styled.div`
       display: flex;
       align-items: center;
       justify-content: center;
+      margin-top: 0.3rem;
       svg {
         width: 1.4rem;
         margin-right: 0.1rem;


### PR DESCRIPTION
본문 내용과 좋아요, 댓글 아이콘 간의 간격 늘림

## 수정 전
![image](https://user-images.githubusercontent.com/13381535/151649606-1e873f2d-412a-4d15-9df1-02d96bfb68e8.png)

## 수정 후
![image](https://user-images.githubusercontent.com/13381535/151649614-b7357b4f-1141-4ab4-a99f-8866df4c1ed1.png)
