### PR TITLE
Fix: 에러페이지 글씨 색상 변경, gap 조정

### DIFF
--- a/src/Pages/ErrorPage/ErrorPage.styled.js
+++ b/src/Pages/ErrorPage/ErrorPage.styled.js
@@ -6,7 +6,7 @@ const ErrorBackground = styled.div`
   background: #2a2d38;
   #logo {
     z-index: 0;
-    position: relative;
+    position: fixed;
     top: 20%;
     left: 50%;
     transform: translateX(-50%);

--- a/src/Pages/ErrorPage/ErrorPage.styled.js
+++ b/src/Pages/ErrorPage/ErrorPage.styled.js
@@ -41,7 +41,7 @@ const ErrorBox = styled.div`
   h3 {
     color: #aaaaaa;
     font-size: 0.8rem;
-	font-weight: 300;
+    font-weight: 300;
   }
 `;
 

--- a/src/Pages/ErrorPage/ErrorPage.styled.js
+++ b/src/Pages/ErrorPage/ErrorPage.styled.js
@@ -6,7 +6,7 @@ const ErrorBackground = styled.div`
   background: #2a2d38;
   #logo {
     z-index: 0;
-    position: fixed;
+    position: relative;
     top: 20%;
     left: 50%;
     transform: translateX(-50%);
@@ -27,7 +27,7 @@ const ErrorBox = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 20px;
+  gap: 70px;
   h1 {
     z-index: 1;
     font-size: 6rem;
@@ -36,11 +36,12 @@ const ErrorBox = styled.div`
   h2 {
     position: relative;
     text-align: center;
-    color: #53b7ba;
+    color: #FFFFFF;
   }
   h3 {
     color: #aaaaaa;
-    font-size: 0.5rem;
+    font-size: 0.8rem;
+	font-weight: 300;
   }
 `;
 


### PR DESCRIPTION
변경전:
![image](https://user-images.githubusercontent.com/39411711/151663429-e29bad4f-4511-478f-a411-571d12193115.png)

변경후:
![image](https://user-images.githubusercontent.com/39411711/151663435-3e5c8119-b784-450b-ab58-9f8a1f5b84c2.png)

화면이 작은 경우(ex. iPhone SE) 이미지와 글씨가 겹치는 오류가 있습니다.
세밀한 위치 조정은 추후 작업이 필요합니다.