### PR TITLE
Hotfix : 제목 maxlength 수정.

### DIFF
--- a/src/Pages/CreateArticlePage/Components/CreateArticleBody.jsx
+++ b/src/Pages/CreateArticlePage/Components/CreateArticleBody.jsx
@@ -87,7 +87,7 @@ const CreateArticleBody = () => {
           <input
             placeholder="제목을 입력하세요"
             onChange={handleChangeTitle}
-            maxLength={42}
+            maxLength={30}
           />
           <TextareaAutosize
             placeholder="내용을 입력하세요"

--- a/src/Pages/EditArticlePage/Conponents/EditArticlePageBody.jsx
+++ b/src/Pages/EditArticlePage/Conponents/EditArticlePageBody.jsx
@@ -25,7 +25,7 @@ const EditArticlePageBody = ({
         <input
           placeholder="제목을 입력하세요"
           onChange={onChangeTitle}
-          maxLength={42}
+          maxLength={30}
           value={title}
         />
         <TextareaAutosize


### PR DESCRIPTION
제목 밀리는 현상 방지 위해 임의로 42 -> 30으로 조정.