### PR TITLE
[FIX] 이메일 인증을 영어/숫자/하이픈만 사용가능하도록 변경

### DIFF
--- a/src/Pages/AuthPage/Components/Auth.jsx
+++ b/src/Pages/AuthPage/Components/Auth.jsx
@@ -34,8 +34,8 @@ const AuthRequestCheckStep = ({ handleSendReset }) => {
   );
 };
 
-function checkKor(str) {
-  const regExp = /[ㄱ-ㅎㅏ-ㅣ가-힣]/g;
+function checkIntraId(str) {
+  const regExp = /[A-Za-z0-9-]/g;
   if (regExp.test(str)) {
     return true;
   } else {
@@ -68,7 +68,7 @@ const Auth = () => {
     });
   };
   const handleAuthenticate = () => {
-    if (input.email === '' || checkKor(input.email)) {
+    if (input.email === '' || !checkIntraId(input.email)) {
       setIsError(true);
       setTimeout(() => {
         setIsError(false);


### PR DESCRIPTION
기존에는 한글이 아닌 경우, 인증메일이 발송되었습니다. 그래서 이메일 전체를 입력하는 사람( 예시) 나)의 경우 오류 메세지가 출력이 되지 않았는데요. 영어/숫자/하이픈만 허용하도록 바꾸어 이메일을 입력해도 에러 메세지가 뜨도록 변경했습니다.