### PR TITLE
Fix/view count

### DIFF
--- a/src/Pages/ArticlePage/ArticlePage.jsx
+++ b/src/Pages/ArticlePage/ArticlePage.jsx
@@ -1,27 +1,17 @@
-import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { Body, CommentContainer } from './Components';
-import { Header } from '../../Components';
+import { Body } from './Components';
+import { Header } from 'Components';
 
 import Styled from './ArticlePage.styled';
-import ArticleService from 'Network/ArticleService';
 const ArticlePage = () => {
   const { id } = useParams();
-  const [categoryId, setCategoryId] = useState(0);
-  const getCate = async () => {
-    const result = await ArticleService.getArticlesById(id);
-    setCategoryId(result.categoryId);
-  };
-  useEffect(() => {
-    getCate();
-  }, []);
 
   return (
     <>
       <Header />
       <Styled.ArticlePageDiv>
-        <Body articleId={id} categoryId={categoryId} />
-        {categoryId !== 3 && <CommentContainer articleId={id} />}
+        <Body articleId={id} />
+        {/* {categoryId !== 3 && <CommentContainer articleId={id} />} */}
       </Styled.ArticlePageDiv>
     </>
   );

--- a/src/Pages/ArticlePage/Components/Body.jsx
+++ b/src/Pages/ArticlePage/Components/Body.jsx
@@ -20,7 +20,7 @@ const Body = ({ articleId, categoryId }) => {
   const [likeCount, setLikeCount] = useState(0);
   const navi = useNavigate();
   const handleClickEdit = () => {
-    navi(`/article/${articleId}/edit`);
+    navi(`/article/${articleId}/edit`, { state: { article } });
   };
   const handleClickDelete = () => {
     ArticleService.deleteArticles(articleId);

--- a/src/Pages/ArticlePage/Components/Body.jsx
+++ b/src/Pages/ArticlePage/Components/Body.jsx
@@ -1,17 +1,18 @@
-import { FavoriteBorder, SmsOutlined } from '@mui/icons-material';
+import { FavoriteBorder } from '@mui/icons-material';
 import FavoriteIcon from '@mui/icons-material/Favorite';
 import { useState, useEffect, useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import { getCategoryById } from '../../../Utils';
+import { getCategoryById } from 'Utils';
 
-import ArticleService from '../../../Network/ArticleService';
-import { AuthContext } from '../../../App';
-import GlobalStyled from '../../../Styled/Global.styled';
+import ArticleService from 'Network/ArticleService';
+import { AuthContext } from 'App';
+import GlobalStyled from 'Styled/Global.styled';
 import dayjs from 'dayjs';
 import Styled from '../ArticlePage.styled';
 import ReactionService from 'Network/ReactionService';
 import { getProfileImg } from 'Utils/profileList';
+import { CommentContainer } from '.';
 
 const Body = ({ articleId, categoryId }) => {
   const [article, setArticle] = useState();
@@ -23,7 +24,6 @@ const Body = ({ articleId, categoryId }) => {
   };
   const handleClickDelete = () => {
     ArticleService.deleteArticles(articleId);
-    // navi(`/category/${categoryId}`);
     navi(-1);
   };
   const { curUser } = useContext(AuthContext);
@@ -51,45 +51,52 @@ const Body = ({ articleId, categoryId }) => {
 
   if (!article) return <></>;
   return (
-    <div className="content_div">
-      <GlobalStyled.BoardTitleDiv
-        onClick={() => {
-          navi(`/category/${article.categoryId}`);
-        }}
-      >
-        <div className="board_name">{getCategoryById(article.categoryId)}</div>
-      </GlobalStyled.BoardTitleDiv>
-      <div className="content_top">
-        <div className="title">
-          <h1>{article.title}</h1>
-          <div className="info">
-            <h2>{article.writer.nickname}</h2>
-            <h2>{getArticleTime(article.createdAt)}</h2>
-            <h2>조회수 {article.viewCount}</h2>
-            {article.writer.id === curUser.id && (
-              <div className="edit_article">
-                <button onClick={handleClickEdit}>수정</button>
-                {/* <button onClick={handleClickDelete}>삭제</button> */}
-              </div>
-            )}
+    <>
+      <div className="content_div">
+        <GlobalStyled.BoardTitleDiv
+          onClick={() => {
+            navi(`/category/${article.categoryId}`);
+          }}
+        >
+          <div className="board_name">
+            {getCategoryById(article.categoryId)}
           </div>
+        </GlobalStyled.BoardTitleDiv>
+        <div className="content_top">
+          <div className="title">
+            <h1>{article.title}</h1>
+            <div className="info">
+              <h2>{article.writer.nickname}</h2>
+              <h2>{getArticleTime(article.createdAt)}</h2>
+              <h2>조회수 {article.viewCount}</h2>
+              {article.writer.id === curUser.id && (
+                <div className="edit_article">
+                  <button onClick={handleClickEdit}>수정</button>
+                  {/* <button onClick={handleClickDelete}>삭제</button> */}
+                </div>
+              )}
+            </div>
+          </div>
+          <Styled.ProfileImage
+            width="2.5rem"
+            src={getProfileImg(article.writer.character)}
+          ></Styled.ProfileImage>
         </div>
-        <Styled.ProfileImage
-          width="2.5rem"
-          src={getProfileImg(article.writer.character)}
-        ></Styled.ProfileImage>
+        <div className="content_middle">{article.content}</div>
+        <div className="content_bottom">
+          {categoryId !== 3 && (
+            <Styled.ArticleLikedDiv likedCount={likeCount || 0}>
+              <span onClick={handleClickLike}>
+                {isLike ? <FavoriteIcon /> : <FavoriteBorder />}
+              </span>
+            </Styled.ArticleLikedDiv>
+          )}
+        </div>
       </div>
-      <div className="content_middle">{article.content}</div>
-      <div className="content_bottom">
-        {categoryId !== 3 && (
-          <Styled.ArticleLikedDiv likedCount={likeCount || 0}>
-            <span onClick={handleClickLike}>
-              {isLike ? <FavoriteIcon /> : <FavoriteBorder />}
-            </span>
-          </Styled.ArticleLikedDiv>
-        )}
-      </div>
-    </div>
+      {article && article.categoryId !== 3 && (
+        <CommentContainer articleId={articleId} />
+      )}
+    </>
   );
 };
 

--- a/src/Pages/EditArticlePage/EditArticlePage.jsx
+++ b/src/Pages/EditArticlePage/EditArticlePage.jsx
@@ -1,9 +1,8 @@
-import { useState, useEffect, useContext, useRef } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useState, useEffect, useContext } from 'react';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 
-import ArticleService from '../../Network/ArticleService';
-import { AuthContext } from '../../App';
-import { getCategoryByUrl } from '../../Utils';
+import ArticleService from 'Network/ArticleService';
+import { AuthContext } from 'App';
 
 import { EditArticlePageHeader, EditArticlePageBody } from './Conponents';
 import Styled from './EditArticlePage.styled';
@@ -13,11 +12,9 @@ const EditArticlePage = () => {
   const [content, setContent] = useState('');
   const [categoryId, setCategoryId] = useState(0);
 
-  const auth = useContext(AuthContext);
-
   const loca = useLocation();
   const navi = useNavigate();
-  const pathArray = loca.pathname.split('/');
+  const { id } = useParams();
 
   const handleChangeTitle = e => {
     setTitle(e.target.value);
@@ -42,7 +39,7 @@ const EditArticlePage = () => {
     }
     // 수정하려고 카테고리 아이디 API 받는 게 조회로 인식.
     // 이동한 뒤에 API 실행됨
-    const result = await ArticleService.editArticles(+pathArray[2], {
+    const result = await ArticleService.editArticles(id, {
       title: title,
       content: content,
       categoryId: categoryId, // + 붙이면 number 타입
@@ -51,16 +48,16 @@ const EditArticlePage = () => {
   };
 
   useEffect(() => {
-    const getArticle = async () => {
-      const response = await ArticleService.getArticlesById(pathArray[2]);
-      const article = response;
+    if (loca.state) {
+      const { article } = loca.state;
       setTitle(article.title);
       setContent(article.content);
       setCategoryId(article.categoryId);
-    };
-    getArticle();
-  }, [setTitle, setContent, categoryId]);
-
+    } else {
+      alert('없는 페이지입니다');
+      navi('/');
+    }
+  }, []);
   return (
     <Styled.EditArticlePage>
       <EditArticlePageHeader

--- a/src/Pages/MainPage/Components/Community.jsx
+++ b/src/Pages/MainPage/Components/Community.jsx
@@ -1,3 +1,4 @@
+import { Fragment } from 'react';
 import { PreviewArticle } from '../../../Components';
 
 import Styled from './Body.styled';
@@ -19,7 +20,7 @@ const Community = ({
         {bestArticles &&
           bestArticles.map(article => {
             return (
-              <>
+              <Fragment key={article.id}>
                 <img src="/assets/hot.svg" />
                 <PreviewArticle
                   key={article.id}
@@ -27,7 +28,7 @@ const Community = ({
                   article={article}
                   onClickArticle={() => moveArticles(article.id)}
                 />
-              </>
+              </Fragment>
             );
           })}
       </Styled.BestStyledList>


### PR DESCRIPTION
- 게시글 상세페이지에 들어갔을 때 기본적으로 조회수가 두 번 불리던 이유: 공지사항일 때 댓글을 감추기 위해 필요한 카테고리를 불러오기 위해 getArticlesbyId를 호출했음 => commentContainer를 바디 안에 넣어서 바디 안에서 호출한 결과값을 이용하도록 수정
- 수정할 때 더 오르던 이유 => 수정 페이지에서도 getArticlesbyId를 호출함 => 게시글 상세 페이지에서 수정 버튼 클릭시 navigate(URL, {state: {article}})로 article을 넘기도록 수정

이제 게시글 상세페이지에 들어갔을 때만 한번 오르게 변경됐고, 내 글 조회했을 때 조회수 안 올라가게 막으면 1번만 올라갈 것입니다..(아마도) 


https://user-images.githubusercontent.com/68804133/152687887-b6ab397c-11e0-4777-ac79-b2ae4decb944.mov

