### PR TITLE
Feat: 미리보기에서 마크다운, 역슬래시 제거

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "react-scripts": "5.0.0",
         "react-textarea-autosize": "^8.3.3",
         "react-transition-group": "^4.4.2",
+        "remove-markdown": "^0.3.0",
         "styled-components": "^5.3.3",
         "web-vitals": "^2.1.3"
       },
@@ -15294,6 +15295,11 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/remove-markdown": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/remove-markdown/-/remove-markdown-0.3.0.tgz",
+      "integrity": "sha1-XktmdJOpNXlyjz1S7MHbnKUF3Jg="
+    },
     "node_modules/renderkid": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-3.0.0.tgz",
@@ -29299,6 +29305,11 @@
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
       "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk="
+    },
+    "remove-markdown": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/remove-markdown/-/remove-markdown-0.3.0.tgz",
+      "integrity": "sha1-XktmdJOpNXlyjz1S7MHbnKUF3Jg="
     },
     "renderkid": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react-scripts": "5.0.0",
     "react-textarea-autosize": "^8.3.3",
     "react-transition-group": "^4.4.2",
+    "remove-markdown": "^0.3.0",
     "styled-components": "^5.3.3",
     "web-vitals": "^2.1.3"
   },

--- a/src/Components/PreviewArticle.jsx
+++ b/src/Components/PreviewArticle.jsx
@@ -2,16 +2,18 @@ import dayjs from 'dayjs';
 
 import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
 import SmsOutlined from '@mui/icons-material/SmsOutlined';
+import removeMarkdown from 'remove-markdown';
 
 import Styled from './PreviewArticle.styled';
 
 const PreviewArticle = ({ article, isBestArticle, onClickArticle }) => {
   const getArticleTime = time =>
-  dayjs(time).isSame(dayjs(), 'day')
-  ? dayjs(time).format('HH:mm')
-  : dayjs(time).format('MM/DD');
-  const isNewArticle = time => dayjs().isBefore(dayjs(time).add(12, "hour"));
+    dayjs(time).isSame(dayjs(), 'day')
+      ? dayjs(time).format('HH:mm')
+      : dayjs(time).format('MM/DD');
+  const isNewArticle = time => dayjs().isBefore(dayjs(time).add(12, 'hour'));
   isNewArticle(article.createdAt);
+  const getPlainText = text => removeMarkdown(text).replaceAll('\\', '');
   return (
     <Styled.PreviewArticleDiv
       button
@@ -25,7 +27,7 @@ const PreviewArticle = ({ article, isBestArticle, onClickArticle }) => {
         {isNewArticle(article.createdAt) && <img src="/assets/new.svg" />}
         {article.title}
       </div>
-      <div className="middle">{article.content}</div>
+      <div className="middle">{getPlainText(article.content)}</div>
       <div className="bottom">
         {article.writer && <h2>{article.writer.nickname}</h2>}
         <h2>{getArticleTime(article.createdAt)}</h2>

--- a/src/Components/PreviewArticle.jsx
+++ b/src/Components/PreviewArticle.jsx
@@ -1,8 +1,8 @@
 import dayjs from 'dayjs';
+import removeMarkdown from 'remove-markdown';
 
 import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
 import SmsOutlined from '@mui/icons-material/SmsOutlined';
-import removeMarkdown from 'remove-markdown';
 
 import Styled from './PreviewArticle.styled';
 


### PR DESCRIPTION
<img width="391" alt="스크린샷 2022-03-11 오후 1 47 25" src="https://user-images.githubusercontent.com/37893979/157804012-1eea6b80-99f1-4f2a-855a-eb5d8acc3c94.png">

Before

<img width="383" alt="스크린샷 2022-03-11 오후 1 47 45" src="https://user-images.githubusercontent.com/37893979/157804018-019737f8-03e6-4d68-bce0-924771653b65.png">

After

아주 작은 작업 (#205 )
- [x] remove-markdown 라이브러리를 이용해서 마크다운 문법을 전부 제거했습니다
- [x] 일반 텍스트로 기호를 입력할 때 미리보기에서 역슬래시가 출력되는 문제를 전부 replace 했습니다만 불필요한 부분이라면 지워도 될 것 같습니다