### PR TITLE
Fix: 게시글 작성 시 커서가 본문이 아닌 제목으로 가게 수정

### DIFF
--- a/src/Pages/CreateArticlePage/Components/CreateArticleBody.jsx
+++ b/src/Pages/CreateArticlePage/Components/CreateArticleBody.jsx
@@ -26,6 +26,7 @@ const CreateArticleBody = () => {
   const open = Boolean(anchorEl);
 
   const editorRef = useRef(null);
+  const titleRef = useRef(null);
 
   const handleClickPopper = event => {
     setAnchorEl(event.currentTarget);
@@ -86,6 +87,7 @@ const CreateArticleBody = () => {
     if (editorRef.current) {
       markdownEditorSetting();
     }
+    titleRef.current.focus();
   }, [editorRef]);
 
   const handleClick = () => {
@@ -132,6 +134,7 @@ const CreateArticleBody = () => {
             placeholder="제목을 입력하세요"
             onChange={handleChangeTitle}
             maxLength={30}
+            ref={titleRef}
           />
 
           <Editor
@@ -140,6 +143,7 @@ const CreateArticleBody = () => {
             placeholder="내용을 입력하세요"
             onChange={handleChangeContent}
             ref={editorRef}
+            autofocus={false}
           />
         </form>
       </div>


### PR DESCRIPTION
<img width="381" alt="image" src="https://user-images.githubusercontent.com/37893979/159157400-e83eda30-9a5d-4c8e-a20a-0d3e7b87e9fa.png">

#237 이슈 수정하였습니다 (toastUI의 에디터 autofocus 옵션 끄고, titleRef에 focus 추가)
크리티컬 이슈는 아닌 것 같아서 Hotfix 대신 fix로 풀리퀘 올립니다 