### PR TITLE
Design: '자유게시판' 이 상단바를 뚫고 등장하는 현상 수정

### DIFF
--- a/src/Pages/CreateArticlePage/CreateArticlePage.styled.js
+++ b/src/Pages/CreateArticlePage/CreateArticlePage.styled.js
@@ -6,6 +6,7 @@ const CreateArticlePage = styled.div`
   .page_header {
     position: fixed;
 
+    z-index: 999;
     box-sizing: border-box;
     width: 100%;
     display: flex;


### PR DESCRIPTION
<img width="393" alt="image" src="https://user-images.githubusercontent.com/37893979/159157700-7cd59516-a8d9-40ba-881f-80f3dacfb871.png">

#236을 수정하였습니다
- z-index를 999로 설정
